### PR TITLE
Add standard packages so meteor runs properly

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -3,3 +3,4 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
+standard-app-packages


### PR DESCRIPTION
I'm a meteor newbie, so there might be another way to accomplish this (or more required to get the project fully up and running).

This was required to resolve:

[04.1 15:08:13][owen: meteor-the-gathering]$ meteor
[[[[[ ~/Dropbox/magic/meteor-the-gathering ]]]]]

=> Started proxy.
=> Started MongoDB.
W20150126-15:08:28.698(-8)? (STDERR)
W20150126-15:08:28.700(-8)? (STDERR) /Users/owen/Dropbox/magic/meteor-the-gathering/.meteor/local/build/programs/server/boot.js:246
W20150126-15:08:28.700(-8)? (STDERR) }).run();
W20150126-15:08:28.700(-8)? (STDERR)    ^
W20150126-15:08:28.701(-8)? (STDERR) ReferenceError: Meteor is not defined
W20150126-15:08:28.701(-8)? (STDERR)     at app/model.js:1:48
W20150126-15:08:28.701(-8)? (STDERR)     at app/model.js:68:3
...

After doing `meteor add standard-app-packages` it ran fine.